### PR TITLE
Updating the link so it works inside Obsidian and VSCode.

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Towards community guidlines for empirical studies in software engineering involv
 {: .fs-6 .fw-300 }
 
 This website hosts a draft of community guidlines for empirical studies in software engineering involving LLMs.
-We present a first taxonomy of [study types](/study-types) and corresponding [guidelines](/guidelines).
+We present a first taxonomy of [study types](/study-types) and corresponding [guidelines](/guidelines/index).
 
 The current draft is based on a [position paper](https://arxiv.org/abs/2411.07668) as well as discussion during the [ISERN](https://isern.iese.de/) 2024 meeting and the 2nd [Copenhagen Symposium on Human-Centered Software Engineering AI](https://www.danielrusso.org/copenhagen-symposium-human-centered-ai-software-engineering/).
 To contribute to the guidelines, you can open an issue or a pull request in [our GitHub repository](https://github.com/se-ubt/llm-guidelines).


### PR DESCRIPTION
Ehi @sbaltes , I started editing in Obsidian and the link in the [proposed change](https://github.com/se-ubt/llm-guidelines-website/pull/9/files) does not work. Tried it in VSCode and it also does not work. So this is why the change. 

Which brings me to: what editor do you use? I think it might make sense to try to align a bit here - otherwise different tools will render markdown a bit differently and we might end up doing a lot of formatting changes... E.g., my VSCode with Prettier installed already went ahead and changed the `*` in the list of contributors with `-` when I simply updated my homepage URL. This is why I eventually switched to editing with Obsidian, but there the internal link syntax is different... :))