### PR TITLE
Address TODOs in "Report Suitable Baselines, Benchmarks, and Metrics

### DIFF
--- a/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
+++ b/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
@@ -31,18 +31,16 @@ Researchers \should always check whether such traditional baselines exist and if
 
 For comparing traditional and LLM-based approaches or different LLM-based tools, researchers \should use established metrics whenever possible (see examples below), as this enables secondary research.
 Researchers \must argue why the selected metrics are suitable for the given task or study. 
-If a study evaluates an LLM-based tool that is supposed to support humans, a relevant metric might be the acceptance rate, meaning the ratio of all accepted artifacts (e.g., test cases, code snippets) in relation to all artifacts that were generated and presented to the user.
+If a study evaluates an LLM-based tool that is supposed to support humans, a relevant metric is the acceptance rate, meaning the ratio of all accepted artifacts (e.g., test cases, code snippets) in relation to all artifacts that were generated and presented to the user.
 Another way of evaluating LLM-based tools is calculating inter-model agreement (see also Section \href{/guidelines/#use-an-open-llm-as-a-baseline}{Use an Open LLM as a Baseline}).
-This also allows researchers to assess how dependent a tool's performance is on specific models.
-\todo{What are suitable metrics for comparing inter-model agreement?}
+This allows researchers to assess how dependent a tool's performance is on specific models.
+Metrics used to measure inter-model agreements are percent agreement, Cohen's kappa and Scott's Pi coefficient.
 
 LLM-based generation is non-deterministic by-design.
 Due to this non-determinism, researchers \should repeat experiments to statistically assess the performance of a model or tool, for example using the arithmetic mean, confidence intervals, and standard deviations.
 
 
 \subsubsection{Example(s)}
-
-\todo{Sebastian: Examples of SE papers using certain benchmarks, baseline, or metrics are still missing. See also the TODO at the end of this section, which was added during the previous review round.}
 
 Two benchmarks used for code generation are \emph{HumanEval} (\href{https://github.com/openai/human-eval}{GitHub}) \cite{DBLP:conf/acl/PapineniRWZ02} and \emph{MBPP} (\href{https://huggingface.co/datasets/google-research-datasets/mbpp}{GitHub}) \cite{DBLP:journals/corr/abs-2108-07732}.
 Both benchmarks consist of code snippets written in Python sourced from publicly available repositories.
@@ -59,7 +57,7 @@ Common metrics for assessing generation tasks are \emph{BLEU}, \emph{pass@k}, \e
 The most common recommendation task metric is \emph{Mean Reciprocal Rank}~\cite{10.1145/3695988}.
 For classification tasks, classical machine learning metrics such as \emph{Precision}, \emph{Recall}, \emph{F1-score}, and \emph{Accuracy} are often reported \cite{10.1145/3695988}.
 
-We now briefly discuss two common metrics used for generation tasks.
+Now, we briefly discuss two common metrics used for generation tasks.
 \emph{BLEU-N} \cite{DBLP:conf/acl/PapineniRWZ02} is a similarity score based on n-gram precision between two strings, ranging from $0$ to $1$.
 Values close to $0$ depict dissimilar values closer to $1$ represent similar content.
 A value closer to $1$ indicates that the model is more capable of generating the expected output for code generation.
@@ -73,7 +71,7 @@ As mentioned above, researchers should motivate why they chose a certain metric 
 The metric \emph{pass@k} reports the likelihood of a model correctly completing a code snippet at least once within \emph{k} tries.
 To the best of our knowledge, the basic concept of pass@k was first used in \cite{DBLP:journals/corr/abs-1906-04908} for evaluating code synthesis under the name \emph{success rate at B}, where B denotes the budget of trials.
 The term pass@k was later popularized by \cite{DBLP:journals/corr/abs-2107-03374} as a metric for code generation correctness.
-The exact definition of correctness varies depending on the task
+The exact definition of correctness varies depending on the task.
 For code generation, correctness is often defined based on test cases. A passing test then means that the solution is correct.
 The resulting pass rate ranges from $0$ to $1$.
 A pass rate of $0$ indicates that the model was not able to generate a single correct solution within $k$ tries.
@@ -96,15 +94,20 @@ For downstream tasks that permit multiple solutions or user interaction, strong 
 For instance, a user selecting the correct test case from multiple suggestions allows for some model errors.
 %In code search, finding the most appropriate good snippet for a given context, a reranking algorithm mitigate low pass rates at low k-values.
 Common examples for papers using pass@k are papers introducing new models for code generation such as \cite{DBLP:journals/corr/abs-2308-12950, DBLP:journals/corr/abs-2401-14196, DBLP:journals/corr/abs-2409-12186, DBLP:journals/corr/abs-2305-06161}.
-
-\todo{Find SE papers which uses other benchmarks than pass@k \& other papers which do not introduce a new model.}
-
 %\subsubsection{Exact Match}
 
 \emph{Exact match} is another metric that calculates the percentage of replicas a model can produce.
 If the model is able to produce the exact target sequence a score of 1 is awarded; otherwise 0.
 Compared to BLEU-N, \emph{exact match} is a stricter measurement.
 %Due to its strictness, reported scores are usually low.
+
+The choice of metrics strongly depends on the specific task.
+Consequently, papers addressing different research questions employ different metrics.
+For example, \cite{DBLP:conf/nips/LiuXW023} assesses LLM models for their correctness on code generation using pass@k.
+However, pass@k is not an universal metric suitable for every problem at hand.
+For instance, for creative or open-ended tasks such as comment generation, pass@k is not a suitable metric since not a single correct result exists.
+Thus, \cite{DBLP:conf/icse/GengWD00JML24} evaluates LLMs for code comment generation using BLEU, ROUGE-L and METEOR as evaluation metrics.
+\cite{DBLP:journals/ase/LiuJZNLL25} investigates the performance of LLMs on automated refactorings tasks and proposes a novel metric tailored to the unique characteristics of this problem.
 
 %Code snippets provided by benchmarks contain untrusted code, making sandboxing recommendable.
 %To avoid potential security risks, execute untrusted code in an isolated environment, such as a virtual machine or containerization, instead of your own environment.
@@ -132,7 +135,6 @@ While researchers should compare performance against these models, they must con
 
 Challenges with individual metrics include that, for example, \emph{BLEU-N} is a syntactic metric and hence does not measure semantic correctness or structural correctness.
 Thus, a high \emph{BLEU-N} score does not directly indicate that the generated code is executable.
-%\todo{Mention that alternatives exist? Do they come with other downsides?}
 While alternatives exist, they often come with their own limitations.
 For instance, \emph{Exact Match} is a strict measurement that does not account for functional equivalence but syntactically different code.
 Execution-based metrics (e.g. pass@k) directly evaluate correctness by running test cases, but they require a setup with an execution environment.
@@ -161,20 +163,26 @@ For unforeseen scenarios, however, the model might perform much worse.
 
 \subsubsection{Study Types}
 
-\todo{Connect guideline to study types and for each type have bullet point lists with information that MUST, SHOULD, or MAY be reported (usage of those terms according to RFC 2119~\cite{rfc2119}).}
+This guideline \must be followed for all study types that automatically evaluates the performance of LLMs or LLM-based tools.
 
-This guideline \must be followed for all study types that evaluate the performance of LLMs or LLM-based tools.
+The guideline recommendations are divided into recommendations for benchmark creation and the usage of a benchmark for evaluation.
 
 For example, for \annotators, the research goal might be to assess which model comes closes to a ground truth dataset created by human annotators.
 Especially for open annotation tasks, it is important to select suitable metrics to compare LLM-generated an human-generated labels.
 In general, annotation tasks can vary significantly: Are multiple labels allowed for the same sequence? Are the available labels predefined, or should the LLM generate a set of labels independently?
 Due to this task dependence, it is important that researches justify their metric choice, explaining what aspects of the task it captures and what its limitations are.
 
-\todo{Sebastian: Extend this and look at the comment below that is still unresolved.}
 If researchers assess a well-established task, such as code generation, they \should report standard metrics like pass@k and compare to other models.
+If non-standard metrics are used they \must state the reasoning.
 
-\todo{Describe more study types. Copy common outline for this section.}
+Researcher \should follow existing guidelines for benchmark creation such as \cite{cao2025should} independent of the study type.
 
+\todo{Connect guideline to study types and for each type have bullet point lists with information that MUST, SHOULD, or MAY be reported (usage of those terms according to RFC 2119~\cite{rfc2119}).}
+
+% What are characteristics of a specific study type?
+% - 
+
+% Benchmark
 \subsubsection{References}
 
 \bibliographystyle{plainnat}

--- a/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
+++ b/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
@@ -168,10 +168,10 @@ The design of a benchmark and the selection of appropriate metrics are highly de
 Recommending specific metrics for specific study types is beyond the scope of these guidelines, but Cao et al. provide a good starting point and overview of existing metrics for evaluating LLMs~\cite{10.1145/3695988}.
 Section \humanvalidation provides an overview of integrating human evaluation in LLM-based studies. 
 
-Furthermore, for \annotators, the research goal might be to assess which model comes close to a ground truth dataset created by human annotators.
+For example, for \annotators, the research goal might be to assess which model comes close to a ground truth dataset created by human annotators.
 Especially for open annotation tasks, selecting suitable metrics to compare LLM-generated and human-generated labels is important.
 In general, annotation tasks can vary significantly: Are multiple labels allowed for the same sequence? Are the available labels predefined, or should the LLM generate a set of labels independently?
-Due to this task dependence, it is important that researches justify their metric choice, explaining what aspects of the task it captures and what its limitations are.
+Due to this task dependence, researchers \must justify their metric choice, explaining what aspects of the task it captures and its limitations.
 
 If researchers assess a well-established task, e.g. code generation, they \should report standard metrics pass@k and compare to other models.
 If non-standard metrics are used they \must state the reasoning.

--- a/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
+++ b/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
@@ -164,8 +164,7 @@ For unforeseen scenarios, however, the model might perform much worse.
 \subsubsection{Study Types}
 
 This guideline \must be followed for all study types that automatically evaluates the performance of LLMs or LLM-based tools.
-
-The guideline recommendations are divided into recommendations for benchmark creation and the usage of a benchmark for evaluation.
+The design of a benchmark and the selection of appropriate metrics are highly dependent on the specific study type and research goal.
 
 For example, for \annotators, the research goal might be to assess which model comes closes to a ground truth dataset created by human annotators.
 Especially for open annotation tasks, it is important to select suitable metrics to compare LLM-generated an human-generated labels.
@@ -174,10 +173,7 @@ Due to this task dependence, it is important that researches justify their metri
 
 If researchers assess a well-established task, such as code generation, they \should report standard metrics like pass@k and compare to other models.
 If non-standard metrics are used they \must state the reasoning.
-
-Researcher \should follow existing guidelines for benchmark creation such as \cite{cao2025should} independent of the study type.
-
-\todo{Connect guideline to study types and for each type have bullet point lists with information that MUST, SHOULD, or MAY be reported (usage of those terms according to RFC 2119~\cite{rfc2119}).}
+If non-standard metrics are used they \must state the reasoning.
 
 % What are characteristics of a specific study type?
 % - 

--- a/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
+++ b/guidelines/_sources/07_report-baselines-benchmarks-and-metrics.tex
@@ -103,11 +103,11 @@ Compared to BLEU-N, \emph{exact match} is a stricter measurement.
 
 The choice of metrics strongly depends on the specific task.
 Consequently, papers addressing different research questions employ different metrics.
-For example, \cite{DBLP:conf/nips/LiuXW023} assesses LLM models for their correctness on code generation using pass@k.
+For example, Liu et al. assesses LLM models for their correctness on code generation using pass@k~\cite{DBLP:conf/nips/LiuXW023}.
 However, pass@k is not an universal metric suitable for every problem at hand.
-For instance, for creative or open-ended tasks such as comment generation, pass@k is not a suitable metric since not a single correct result exists.
-Thus, \cite{DBLP:conf/icse/GengWD00JML24} evaluates LLMs for code comment generation using BLEU, ROUGE-L and METEOR as evaluation metrics.
-\cite{DBLP:journals/ase/LiuJZNLL25} investigates the performance of LLMs on automated refactorings tasks and proposes a novel metric tailored to the unique characteristics of this problem.
+For instance, for creative or open-ended tasks such as comment generation, pass@k is not a suitable metric since not only one single correct result exists.
+Thus, Geng et al. evaluates LLMs for code comment generation using BLEU, ROUGE-L and METEOR as evaluation metrics~\cite{DBLP:conf/icse/GengWD00JML24}.
+Liu et al. investigates the performance of LLMs on automated refactorings tasks and proposes a novel metric tailored to the unique characteristics of this problem \cite{DBLP:journals/ase/LiuJZNLL25}.
 
 %Code snippets provided by benchmarks contain untrusted code, making sandboxing recommendable.
 %To avoid potential security risks, execute untrusted code in an isolated environment, such as a virtual machine or containerization, instead of your own environment.
@@ -163,18 +163,18 @@ For unforeseen scenarios, however, the model might perform much worse.
 
 \subsubsection{Study Types}
 
-This guideline \must be followed for all study types that automatically evaluates the performance of LLMs or LLM-based tools.
+This guideline \must be followed for all study types that automatically evaluate the performance of LLMs or LLM-based tools.
 The design of a benchmark and the selection of appropriate metrics are highly dependent on the specific study type and research goal.
+Recommending specific metrics for specific study types is beyond the scope of these guidelines, but Cao et al. provide a good starting point and overview of existing metrics for evaluating LLMs~\cite{10.1145/3695988}.
+Section \humanvalidation provides an overview of integrating human evaluation in LLM-based studies. 
 
-For example, for \annotators, the research goal might be to assess which model comes closes to a ground truth dataset created by human annotators.
-Especially for open annotation tasks, it is important to select suitable metrics to compare LLM-generated an human-generated labels.
+Furthermore, for \annotators, the research goal might be to assess which model comes close to a ground truth dataset created by human annotators.
+Especially for open annotation tasks, selecting suitable metrics to compare LLM-generated and human-generated labels is important.
 In general, annotation tasks can vary significantly: Are multiple labels allowed for the same sequence? Are the available labels predefined, or should the LLM generate a set of labels independently?
 Due to this task dependence, it is important that researches justify their metric choice, explaining what aspects of the task it captures and what its limitations are.
 
-If researchers assess a well-established task, such as code generation, they \should report standard metrics like pass@k and compare to other models.
+If researchers assess a well-established task, e.g. code generation, they \should report standard metrics pass@k and compare to other models.
 If non-standard metrics are used they \must state the reasoning.
-If non-standard metrics are used they \must state the reasoning.
-
 % What are characteristics of a specific study type?
 % - 
 

--- a/literature.bib
+++ b/literature.bib
@@ -318,6 +318,51 @@ keywords = {Software Engineering, Large Language Model, Survey}
   year={2024}
 }
 
+
+@article{DBLP:journals/ase/LiuJZNLL25,
+  author       = {Bo Liu and
+                  Yanjie Jiang and
+                  Yuxia Zhang and
+                  Nan Niu and
+                  Guangjie Li and
+                  Hui Liu},
+  title        = {Exploring the potential of general purpose LLMs in automated software
+                  refactoring: an empirical study},
+  journal      = {Autom. Softw. Eng.},
+  volume       = {32},
+  number       = {1},
+  pages        = {26},
+  year         = {2025},
+  url          = {https://doi.org/10.1007/s10515-025-00500-0},
+  doi          = {10.1007/S10515-025-00500-0},
+  timestamp    = {Mon, 31 Mar 2025 15:49:36 +0200},
+  biburl       = {https://dblp.org/rec/journals/ase/LiuJZNLL25.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}
+
+@inproceedings{DBLP:conf/icse/GengWD00JML24,
+  author       = {Mingyang Geng and
+                  Shangwen Wang and
+                  Dezun Dong and
+                  Haotian Wang and
+                  Ge Li and
+                  Zhi Jin and
+                  Xiaoguang Mao and
+                  Xiangke Liao},
+  title        = {Large Language Models are Few-Shot Summarizers: Multi-Intent Comment
+                  Generation via In-Context Learning},
+  booktitle    = {Proceedings of the 46th {IEEE/ACM} International Conference on Software
+                  Engineering, {ICSE} 2024, Lisbon, Portugal, April 14-20, 2024},
+  pages        = {39:1--39:13},
+  publisher    = {{ACM}},
+  year         = {2024},
+  url          = {https://doi.org/10.1145/3597503.3608134},
+  doi          = {10.1145/3597503.3608134},
+  timestamp    = {Sun, 19 Jan 2025 13:14:49 +0100},
+  biburl       = {https://dblp.org/rec/conf/icse/GengWD00JML24.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}
+
 @inproceedings{DBLP:conf/icse/PerryPV00,
   author       = {Dewayne E. Perry and
                   Adam A. Porter and


### PR DESCRIPTION
This PR addresses the open TODO related to benchmark guidelines by fleshing out recommendations for the section on “Report Suitable Baselines, Benchmarks, and Metrics.”

For me, the main challenge lies in the “Study Types” subsection. Benchmarks are a requirement for all study types that involve automatic evaluation of LLMs or LLM-based tools. However, the design of a benchmark and the selection of appropriate metrics are highly dependent on the specific study type.

Two possible directions:
	1.	General approach – Describe best practices for using and creating benchmarks that apply broadly across all study types (similar to "How Should I Build A Benchmark?" https://arxiv.org/abs/2501.10711) 
	2.	Study-type-specific approach – Define concrete recommendations per study type (e.g., code generation, annotation, classification), including:
	•	What must/should/may be reported (RFC 2119).
	•	Which metrics are suitable and why.

Additionally, this section could distinguish between benchmark creators and benchmark users, as their responsibilities and reporting requirements differ.